### PR TITLE
bump highlight.js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,9 +47,9 @@
       }
     },
     "highlight.js": {
-      "version": "9.15.9",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.9.tgz",
-      "integrity": "sha512-M0zZvfLr5p0keDMCAhNBp03XJbKBxUx5AfyfufMdFMEP4N/Xj6dh0IqC75ys7BAzceR34NgcvXjupRVaHBPPVQ==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.5.1.tgz",
+      "integrity": "sha512-LKzHqnxr4CrD2YsNoIf/o5nJ09j4yi/GcH5BnYz9UnVpZdS4ucMgvP61TDty5xJcFGRjnH4DpujkS9bHT3hq0Q==",
       "dev": true
     },
     "inflight": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/highlightjs/highlightjs-supercollider#readme",
   "devDependencies": {
-    "highlight.js": "^9.15.9",
+    "highlight.js": "^11.5.1",
     "jasmine": "^3.4.0"
   }
 }


### PR DESCRIPTION
Highlight.js seems to have a security vulnerability, therefore an update is necessary.

Closes #6 